### PR TITLE
Set the player status early on before sending signal

### DIFF
--- a/Source/FRadioPlayer.swift
+++ b/Source/FRadioPlayer.swift
@@ -283,9 +283,9 @@ open class FRadioPlayer: NSObject {
      */
     open func stop() {
         guard let player = player else { return }
+        playbackState = .stopped
         player.replaceCurrentItem(with: nil)
         timedMetadataDidChange(rawValue: nil)
-        playbackState = .stopped
     }
     
     /**


### PR DESCRIPTION
I had a need to do some logic when a user hits the Stop button, based on whether
the player was playing or not when they hit it so that I can display the album
artwork or station logo properly. When they hit the Stop button, I was getting
the signal that the metadata has changed but the player status was still "playing".