### PR TITLE
Enhance metadata validators 

### DIFF
--- a/Sources/FRadioPlayer/FRadioAPI.swift
+++ b/Sources/FRadioPlayer/FRadioAPI.swift
@@ -62,7 +62,7 @@ internal struct FRadioAPI {
         // Strip off trailing '[???]' characters left there by ShoutCast and Centova Streams
         // It will leave the string alone if the pattern is not there
         
-        let pattern = "(\\[.*?\\]\\w*$)"
+        let pattern = #"(\(.*?\)\w*)|(\[.*?\]\w*)"#
         guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else { return rawValue }
         
         let rawCleaned = NSMutableString(string: rawValue)

--- a/Sources/FRadioPlayer/FRadioPlayer.swift
+++ b/Sources/FRadioPlayer/FRadioPlayer.swift
@@ -399,8 +399,8 @@ open class FRadioPlayer: NSObject {
     }
     
     private func timedMetadataDidChange(rawValue: String?) {
-        let cleanedRawValue = cleanMetadata(rawValue)
-        let parts = cleanedRawValue?.components(separatedBy: " - ")
+        let metadataCleaned = cleanMetadata(rawValue)
+        let parts = metadataCleaned?.components(separatedBy: " - ")
         delegate?.radioPlayer?(self, metadataDidChange: parts?.first, trackName: parts?.last)
         delegate?.radioPlayer?(self, metadataDidChange: rawValue)
         shouldGetArtwork(for: rawValue, enableArtwork)

--- a/Sources/FRadioPlayer/FRadioPlayer.swift
+++ b/Sources/FRadioPlayer/FRadioPlayer.swift
@@ -399,7 +399,8 @@ open class FRadioPlayer: NSObject {
     }
     
     private func timedMetadataDidChange(rawValue: String?) {
-        let parts = rawValue?.components(separatedBy: " - ")
+        let cleanedRawValue = cleanMetadata(rawValue)
+        let parts = cleanedRawValue?.components(separatedBy: " - ")
         delegate?.radioPlayer?(self, metadataDidChange: parts?.first, trackName: parts?.last)
         delegate?.radioPlayer?(self, metadataDidChange: rawValue)
         shouldGetArtwork(for: rawValue, enableArtwork)
@@ -418,7 +419,16 @@ open class FRadioPlayer: NSObject {
             }
         })
     }
-
+    
+    private func cleanMetadata(_ rawValue: String?) -> String? {
+        guard let rawValue = rawValue else { return nil }
+        return rawValue.replacingOccurrences(
+            of: #"(\(.*?\)\w*)|(\[.*?\]\w*)"#,
+            with: "",
+            options: .regularExpression
+        )
+    }
+    
     private func reloadItem() {
         player?.replaceCurrentItem(with: nil)
         player?.replaceCurrentItem(with: playerItem)


### PR DESCRIPTION
Some radio stations send metadata in special format:
Awolnation - The Best (2019)
Meg Myers - Running Up That Hill (Radio Edit) [2019]
David Bowie - Space Oddity(CD)

And when the `FRadioAPI.getArtwork` wants to get the artwork it response nothing, but with this implementation I update regex validator to delete no necessary information.
It deletes all inside in () and []

Awolnation - The Best 
Meg Myers - Running Up That Hill 
David Bowie - Space Oddity

It also clean metadata on `timedMetadataDidChange` in `FRadioPlayer`