### PR TITLE
Custom/fs/avurl asset prefer precise duration and timing key

### DIFF
--- a/Example/FRadioPlayer/ViewController.swift
+++ b/Example/FRadioPlayer/ViewController.swift
@@ -42,7 +42,11 @@ class ViewController: UIViewController {
                     Station(name: "Sample Audio File",
                             detail: "mp3, 45 seconds",
                             url: URL(string: "https://file-examples-com.github.io/uploads/2017/11/file_example_MP3_700KB.mp3")!,
-                            image: #imageLiteral(resourceName: "audiofile"))]
+                            image: #imageLiteral(resourceName: "audiofile")),
+                    
+                    Station(name: "Sample Audio Streaming", detail: ".flac", url: URL(string: "https://www.eclassical.com/custom/eclassical/files/BIS1447-002-flac_24.flac")!, image: #imageLiteral(resourceName: "audiofile"))
+    
+    ]
     
     // Selected station index
     var selectedIndex = 0 {

--- a/Source/FRadioPlayer.swift
+++ b/Source/FRadioPlayer.swift
@@ -371,7 +371,7 @@ open class FRadioPlayer: NSObject {
         guard let url = url else { state = .urlNotSet; return }
 
         state = .urlNotLoaded
-        asset = AVAsset(url: url)
+        asset = AVURLAsset(url: url, options: [AVURLAssetPreferPreciseDurationAndTimingKey : true])
 
         guard isAutoPlay else { return }
         
@@ -442,7 +442,7 @@ open class FRadioPlayer: NSObject {
 
     private func reloadItem() {
         guard let url = radioURL else { return }
-        asset = AVAsset(url: url)
+        asset = AVURLAsset(url: url, options: [AVURLAssetPreferPreciseDurationAndTimingKey : true])
         guard let asset = asset else { return }
         playerItem = AVPlayerItem(asset: asset)
         player.replaceCurrentItem(with: nil)


### PR DESCRIPTION
- adding option AVURLAssetPreferPreciseDurationAndTimingKey to make loaded song duration and time elapsed is more precision especially when play .flac online song  
- change AVAsset to AVURLAsset because setup like AVURLAssetPreferPreciseDurationAndTimingKey , etc only can be set on class AVURLAsset


note: this only for brach FS