### PR TITLE
Change deprecated class to AnyObject keyword

### DIFF
--- a/Sources/FRadioPlayer/FRadioPlayer.swift
+++ b/Sources/FRadioPlayer/FRadioPlayer.swift
@@ -76,7 +76,7 @@ import AVFoundation
  The `FRadioPlayerDelegate` protocol defines methods you can implement to respond to playback events associated with an `FRadioPlayer` object.
  */
 
-@objc public protocol FRadioPlayerDelegate: class {
+@objc public protocol FRadioPlayerDelegate: AnyObject {
     /**
      Called when player changes state
      

--- a/Sources/FRadioPlayer/Reachability.swift
+++ b/Sources/FRadioPlayer/Reachability.swift
@@ -43,7 +43,7 @@ public extension Notification.Name {
     static let reachabilityChanged = Notification.Name("reachabilityChanged")
 }
 
-public class Reachability {
+public final class Reachability {
     
     public typealias NetworkReachable = (Reachability) -> ()
     public typealias NetworkUnreachable = (Reachability) -> ()


### PR DESCRIPTION
Change deprecated class to AnyObject keyword.
Add "final" to Reachability class, because Reachability will no be inherited by other class.